### PR TITLE
Refactor pipeline into modular orchestrator

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,32 @@
+time_window:
+  since: "6h"
+fetcher:
+  sources_path: "sources.json"
+  min_chars: 400
+  max_per_source: 200
+  concurrency: 8
+  timeout: 30
+  user_agent: "market-radar/1.0"
+  feed_retries: 2
+density:
+  model_id: "BAAI/bge-m3"
+  model_cache_dir: null
+  title_score: 0.7
+  content_score: 0.3
+  content_chars: 300
+  batch_size: 64
+  window_hours: 24
+summarizer:
+  model: "openrouter/auto"
+  temperature: 0.2
+  timeout: 60
+  api_key: null
+  fallback_summary: true
+hotness:
+  weights:
+    time: 0.4
+    density: 0.3
+    domain: 0.3
+  time_decay: 4.0
+output:
+  path: "output/news_hotness.json"

--- a/market_radar/__init__.py
+++ b/market_radar/__init__.py
@@ -1,0 +1,11 @@
+"""Market Radar pipeline package."""
+
+from .config import PipelineConfig
+from .models import Article
+from .orchestrator import NewsPipelineOrchestrator
+
+__all__ = [
+    "Article",
+    "PipelineConfig",
+    "NewsPipelineOrchestrator",
+]

--- a/market_radar/config.py
+++ b/market_radar/config.py
@@ -1,0 +1,149 @@
+"""Configuration models and loaders for the Market Radar pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+@dataclass
+class TimeWindowConfig:
+    """Configuration for the time window used to collect news."""
+
+    since: str
+    timezone: Optional[str] = None
+
+
+@dataclass
+class FetcherConfig:
+    """Configuration for RSS/news fetching."""
+
+    sources_path: Path
+    min_chars: int = 400
+    max_per_source: int = 200
+    concurrency: int = 8
+    timeout: int = 30
+    user_agent: str = "market-radar/1.0"
+    feed_retries: int = 2
+
+
+@dataclass
+class DensityConfig:
+    """Configuration for the density estimator."""
+
+    model_id: str
+    model_cache_dir: Optional[Path] = None
+    title_score: float = 0.7
+    content_score: float = 0.3
+    content_chars: int = 300
+    batch_size: int = 64
+    window_hours: int = 24
+
+
+@dataclass
+class SummarizerConfig:
+    """Configuration for the LLM summarizer."""
+
+    model: str
+    temperature: float = 0.2
+    timeout: int = 60
+    api_key: Optional[str] = None
+    fallback_summary: bool = True
+
+
+@dataclass
+class HotnessWeights:
+    """Weights applied when calculating the final hotness score."""
+
+    time: float
+    density: float
+    domain: float
+
+
+@dataclass
+class HotnessConfig:
+    """Configuration of hotness calculation."""
+
+    weights: HotnessWeights
+    time_decay: float = 4.0
+
+
+@dataclass
+class OutputConfig:
+    """Configuration for pipeline output."""
+
+    path: Path
+
+
+@dataclass
+class PipelineConfig:
+    """Root configuration for the orchestrator."""
+
+    time_window: TimeWindowConfig
+    fetcher: FetcherConfig
+    density: DensityConfig
+    summarizer: SummarizerConfig
+    hotness: HotnessConfig
+    output: OutputConfig
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PipelineConfig":
+        """Instantiate :class:`PipelineConfig` from a raw dictionary."""
+
+        time_window = TimeWindowConfig(**data["time_window"])
+
+        fetcher_cfg_raw = {**data.get("fetcher", {})}
+        if "sources_path" in fetcher_cfg_raw:
+            fetcher_cfg_raw["sources_path"] = Path(fetcher_cfg_raw["sources_path"])
+        fetcher = FetcherConfig(**fetcher_cfg_raw)
+
+        density_cfg_raw = {**data.get("density", {})}
+        if "model_cache_dir" in density_cfg_raw and density_cfg_raw["model_cache_dir"]:
+            density_cfg_raw["model_cache_dir"] = Path(density_cfg_raw["model_cache_dir"])
+        density = DensityConfig(**density_cfg_raw)
+
+        summarizer_cfg_raw = {**data.get("summarizer", {})}
+        summarizer = SummarizerConfig(**summarizer_cfg_raw)
+
+        hotness_raw = {**data.get("hotness", {})}
+        weights_raw = hotness_raw.get("weights", {})
+        weights = HotnessWeights(**weights_raw)
+        hotness_raw["weights"] = weights
+        hotness = HotnessConfig(**hotness_raw)
+
+        output_cfg_raw = {**data.get("output", {})}
+        output_cfg_raw["path"] = Path(output_cfg_raw["path"])
+        output = OutputConfig(**output_cfg_raw)
+
+        return cls(
+            time_window=time_window,
+            fetcher=fetcher,
+            density=density,
+            summarizer=summarizer,
+            hotness=hotness,
+            output=output,
+        )
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "PipelineConfig":
+        """Load configuration from a YAML file."""
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("YAML config must contain a mapping at the root")
+        return cls.from_dict(data)
+
+
+__all__ = [
+    "PipelineConfig",
+    "TimeWindowConfig",
+    "FetcherConfig",
+    "DensityConfig",
+    "SummarizerConfig",
+    "HotnessConfig",
+    "HotnessWeights",
+    "OutputConfig",
+]

--- a/market_radar/density_estimator.py
+++ b/market_radar/density_estimator.py
@@ -1,0 +1,202 @@
+"""Density estimation for Market Radar news articles."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+
+from .config import DensityConfig
+from .models import Article
+
+
+def clean_text(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    import re
+
+    strip_tags = re.compile(r"<[^>]+>")
+    ws_re = re.compile(r"\s+")
+    text = strip_tags.sub(" ", text)
+    text = ws_re.sub(" ", text).strip()
+    return text
+
+
+def lead(text: Optional[str], max_chars: int) -> str:
+    if not text:
+        return ""
+    text = clean_text(text)
+    if not text:
+        return ""
+    import re
+
+    parts = re.split(r"(?<=[.!?])\s+", text)
+    head = " ".join(parts[:2])
+    if len(head) > max_chars:
+        head = head[:max_chars]
+    return head
+
+
+def has_cuda() -> bool:
+    try:
+        import torch  # noqa: F401
+
+        return torch.cuda.is_available()
+    except Exception:  # pragma: no cover - torch optional
+        return False
+
+
+def get_model(model_id: str, model_cache_dir: Optional[str]):
+    from sentence_transformers import SentenceTransformer
+
+    device = "cuda" if has_cuda() else "cpu"
+    if model_cache_dir:
+        from pathlib import Path
+
+        cache_path = Path(model_cache_dir)
+        cache_path.mkdir(parents=True, exist_ok=True)
+        local_files = {"config.json", "modules.json", "model.safetensors", "pytorch_model.bin"}
+        if any((cache_path / f).exists() for f in local_files) or any(cache_path.glob("**/config.json")):
+            return SentenceTransformer(str(cache_path), device=device)
+        return SentenceTransformer(model_id, cache_folder=str(cache_path), device=device)
+    return SentenceTransformer(model_id, device=device)
+
+
+def encode_texts(
+    model,
+    titles: Sequence[str],
+    contents: Sequence[str],
+    title_score: float,
+    content_score: float,
+    batch_size: int,
+) -> np.ndarray:
+    titles_prep = [("passage: " + t) if t else "" for t in titles]
+    contents_prep = [("passage: " + c) if c else "" for c in contents]
+
+    e_title = model.encode(
+        titles_prep,
+        batch_size=batch_size,
+        convert_to_numpy=True,
+        show_progress_bar=False,
+        normalize_embeddings=True,
+    )
+    e_content = model.encode(
+        contents_prep,
+        batch_size=batch_size,
+        convert_to_numpy=True,
+        show_progress_bar=False,
+        normalize_embeddings=True,
+    )
+
+    w_t = np.array([title_score if bool(t) else 0.0 for t in titles], dtype=np.float32)[:, None]
+    w_c = np.array([content_score if bool(c) else 0.0 for c in contents], dtype=np.float32)[:, None]
+    w_sum = w_t + w_c
+    w_sum = np.where(w_sum == 0.0, 1.0, w_sum)
+
+    combined = (w_t * e_title + w_c * e_content) / w_sum
+    norms = np.linalg.norm(combined, axis=1, keepdims=True)
+    norms = np.maximum(norms, 1e-12)
+    return combined / norms
+
+
+def bucket_key(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+
+def group_by_window(articles: Sequence[Article], window_hours: int) -> Dict[str, List[int]]:
+    groups: Dict[str, List[int]] = {}
+    for idx, art in enumerate(articles):
+        dt = art.best_timestamp()
+        key = bucket_key(dt) if window_hours == 24 else bucket_key(dt)
+        groups.setdefault(key, []).append(idx)
+    return groups
+
+
+def compute_window_scores(
+    idxs: List[int],
+    articles: Sequence[Article],
+    embeddings: np.ndarray,
+) -> Dict[int, float]:
+    if not idxs:
+        return {}
+    window_emb = embeddings[idxs, :]
+    n = window_emb.shape[0]
+    if n == 1:
+        return {idxs[0]: 0.0}
+
+    sim = np.clip(window_emb @ window_emb.T, -1.0, 1.0)
+    dist = 1.0 - sim
+
+    srcs = [articles[i].source_id for i in idxs]
+    srcs_arr = np.array(srcs, dtype=object)
+    same_src = (srcs_arr[:, None] == srcs_arr[None, :])
+    mask = ~same_src
+    np.fill_diagonal(mask, False)
+
+    mean_dist = np.zeros(n, dtype=np.float32)
+    valid = np.zeros(n, dtype=bool)
+    for i in range(n):
+        row_mask = mask[i]
+        vals = dist[i, row_mask]
+        if vals.size > 0:
+            mean_dist[i] = float(vals.mean())
+            valid[i] = True
+        else:
+            mean_dist[i] = np.nan
+            valid[i] = False
+
+    if np.any(valid):
+        md_valid = mean_dist[valid]
+        lo = float(np.min(md_valid))
+        hi = float(np.max(md_valid))
+        if hi > lo:
+            norm = (mean_dist - lo) / (hi - lo)
+        else:
+            norm = np.zeros_like(mean_dist)
+        value = 1.0 - norm
+        value = np.where(np.isfinite(value), value, 0.0)
+    else:
+        value = np.zeros(n, dtype=np.float32)
+
+    return {idxs[i]: float(value[i]) for i in range(n)}
+
+
+class DensityEstimator:
+    """Estimate density coefficients for articles."""
+
+    def __init__(self, config: DensityConfig) -> None:
+        self.config = config
+        self._model = None
+
+    def _ensure_model(self):
+        if self._model is None:
+            cache_dir = str(self.config.model_cache_dir) if self.config.model_cache_dir else None
+            self._model = get_model(self.config.model_id, cache_dir)
+        return self._model
+
+    def estimate(self, articles: Sequence[Article]) -> Dict[int, float]:
+        if not articles:
+            return {}
+
+        model = self._ensure_model()
+        titles = [clean_text(art.title) for art in articles]
+        contents = [lead(art.content, self.config.content_chars) for art in articles]
+
+        embeddings = encode_texts(
+            model=model,
+            titles=titles,
+            contents=contents,
+            title_score=self.config.title_score,
+            content_score=self.config.content_score,
+            batch_size=self.config.batch_size,
+        )
+
+        groups = group_by_window(articles, self.config.window_hours)
+        values: Dict[int, float] = {}
+        for _, idxs in groups.items():
+            values.update(compute_window_scores(idxs, articles, embeddings))
+        return values
+
+
+__all__ = ["DensityEstimator"]

--- a/market_radar/fetching.py
+++ b/market_radar/fetching.py
@@ -1,0 +1,290 @@
+"""News fetching utilities for the Market Radar pipeline."""
+
+from __future__ import annotations
+
+import concurrent.futures as futures
+import random
+import socket
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import feedparser
+import tldextract
+from dateutil import parser as dtparse
+from newsplease import NewsPlease
+
+from .config import FetcherConfig, TimeWindowConfig
+from .models import Article
+
+@dataclass
+class Source:
+    """Representation of a source entry from the sources JSON."""
+
+    id: str
+    type: str
+    urls: Sequence[str]
+
+
+class NewsFetcher:
+    """Collect news articles within a configured time window."""
+
+    def __init__(self, config: FetcherConfig, time_window: TimeWindowConfig) -> None:
+        self.config = config
+        self.time_window = time_window
+
+    @staticmethod
+    def parse_since(value: str) -> timedelta:
+        """Parse a duration string like ``"2h"`` into :class:`timedelta`."""
+
+        value = value.strip().lower()
+        number = ""
+        unit = ""
+        for ch in value:
+            if ch.isdigit():
+                number += ch
+            else:
+                unit += ch
+        if not number or not unit:
+            raise ValueError(f"Invalid time window value: {value}")
+        amount = int(number)
+        unit = unit.strip()
+        mapping = {
+            "s": timedelta(seconds=amount),
+            "m": timedelta(minutes=amount),
+            "h": timedelta(hours=amount),
+            "d": timedelta(days=amount),
+            "w": timedelta(weeks=amount),
+        }
+        if unit not in mapping:
+            raise ValueError(f"Unsupported time unit: {unit}")
+        return mapping[unit]
+
+    @staticmethod
+    def _best_entry_datetime(entry: Dict[str, object]) -> Optional[datetime]:
+        for key in ("published", "pubDate", "updated", "dc_date"):
+            value = entry.get(key)
+            if not value:
+                continue
+            try:
+                dt = dtparse.parse(str(value))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.astimezone(timezone.utc)
+            except Exception:
+                continue
+        for key in ("published_parsed", "updated_parsed"):
+            value = entry.get(key)
+            if not value:
+                continue
+            try:
+                return datetime(*value[:6], tzinfo=timezone.utc)
+            except Exception:
+                continue
+        return None
+
+    def _collect_feed_urls(
+        self,
+        source_id: str,
+        urls: Sequence[str],
+        since_utc: datetime,
+        request_headers: Optional[Dict[str, str]] = None,
+        retries: int = 2,
+        log_error: Optional[Callable[[str, Optional[BaseException]], None]] = None,
+    ) -> List[Tuple[str, Optional[datetime]]]:
+        """Robustly collect links from RSS feeds with retries."""
+
+        collected: List[Tuple[str, Optional[datetime]]] = []
+        headers = request_headers or {}
+        for feed_url in urls:
+            parsed = None
+            last_error: Optional[BaseException] = None
+            for attempt in range(retries + 1):
+                try:
+                    parsed = feedparser.parse(feed_url, request_headers=headers)
+                    break
+                except Exception as exc:  # pragma: no cover - network failure branch
+                    last_error = exc
+                    if attempt < retries:
+                        sleep_s = (1.5 ** attempt) + random.random() * 0.5
+                        time.sleep(sleep_s)
+                    else:
+                        message = (
+                            f"RSS fetch failed after retries | src={source_id} | url={feed_url} | err={exc!r}"
+                        )
+                        if log_error:
+                            log_error(message, exc)
+                        else:
+                            print(f"[w] {message}")
+            if not parsed:
+                continue
+
+            status = getattr(parsed, "status", None)
+            if status and status != 200:
+                message = (
+                    f"non-200 RSS response | src={source_id} | url={feed_url} | status={status}"
+                )
+                if log_error:
+                    log_error(message, last_error)
+                else:
+                    print(f"[w] {message}")
+
+            try:
+                entries = getattr(parsed, "entries", []) or []
+            except Exception as exc:  # pragma: no cover - defensive
+                if log_error:
+                    log_error(f"bad RSS structure | src={source_id} | url={feed_url}", exc)
+                else:
+                    print(f"[w] bad RSS structure | src={source_id} | url={feed_url}")
+                entries = []
+
+            for entry in entries:
+                dt = self._best_entry_datetime(entry)
+                link = entry.get("link") if isinstance(entry, dict) else getattr(entry, "link", "")
+                if not link:
+                    continue
+                if dt is None or dt >= since_utc:
+                    collected.append((str(link), dt))
+
+        unique: List[Tuple[str, Optional[datetime]]] = []
+        seen = set()
+        for url, dt in collected:
+            if url not in seen:
+                unique.append((url, dt))
+                seen.add(url)
+        return unique
+
+    @staticmethod
+    def _extract_article(url: str) -> Optional[NewsPlease]:
+        try:
+            return NewsPlease.from_url(url)
+        except Exception:
+            return None
+
+    def _map_article(
+        self,
+        source_id: str,
+        url: str,
+        guess_dt: Optional[datetime],
+    ) -> Optional[Article]:
+        art = self._extract_article(url)
+        if art is None:
+            return None
+
+        content = getattr(art, "maintext", None)
+        if content and len(content) < self.config.min_chars:
+            return None
+
+        title = getattr(art, "title", None)
+        ext = tldextract.extract(url)
+        domain = ".".join(part for part in [ext.domain, ext.suffix] if part)
+
+        published_dt = getattr(art, "date_publish", None)
+        if isinstance(published_dt, datetime):
+            if published_dt.tzinfo is None:
+                published_dt = published_dt.replace(tzinfo=timezone.utc)
+            published = published_dt.astimezone(timezone.utc)
+        elif guess_dt is not None:
+            published = guess_dt.astimezone(timezone.utc)
+        else:
+            published = None
+
+        crawled_at = datetime.now(timezone.utc)
+        language = getattr(art, "language", None)
+        authors = getattr(art, "authors", None)
+        if not isinstance(authors, list):
+            authors = None
+
+        extras = {
+            "newsplease": {
+                "date_download": str(getattr(art, "date_download", None)),
+                "description": getattr(art, "description", None),
+                "image_url": getattr(art, "image_url", None),
+            }
+        }
+
+        return Article(
+            source_id=source_id,
+            source_domain=domain,
+            url=url,
+            title=title,
+            content=content,
+            published_at=published,
+            crawled_at=crawled_at,
+            language=language,
+            authors=authors,
+            extras=extras,
+        )
+
+    def _load_sources(self) -> List[Source]:
+        import json
+
+        raw = json.loads(self.config.sources_path.read_text(encoding="utf-8"))
+        sources: List[Source] = []
+        for entry in raw:
+            if entry.get("type") != "rss":
+                continue
+            sources.append(
+                Source(id=entry.get("id", ""), type=entry["type"], urls=entry.get("urls", []))
+            )
+        return sources
+
+    def fetch(self, start_time: Optional[datetime] = None) -> List[Article]:
+        """Fetch news articles according to the configured window."""
+
+        if start_time is None:
+            start_time = datetime.now(timezone.utc)
+        since_td = self.parse_since(self.time_window.since)
+        cutoff = start_time - since_td
+
+        socket.setdefaulttimeout(max(1, self.config.timeout))
+
+        sources = self._load_sources()
+        all_tasks: List[Tuple[str, str, Optional[datetime]]] = []
+        for src in sources:
+            urls = self._collect_feed_urls(
+                src.id,
+                src.urls,
+                cutoff,
+                request_headers={"User-Agent": self.config.user_agent},
+                retries=self.config.feed_retries,
+            )
+            if self.config.max_per_source and len(urls) > self.config.max_per_source:
+                urls = urls[: self.config.max_per_source]
+            for url, dt in urls:
+                all_tasks.append((src.id, url, dt))
+
+        if not all_tasks:
+            return []
+
+        results: List[Article] = []
+        lock = Lock()
+
+        def _append(article: Optional[Article]) -> None:
+            if article is None:
+                return
+            with lock:
+                results.append(article)
+
+        with futures.ThreadPoolExecutor(max_workers=self.config.concurrency) as pool:
+            future_to_url = {
+                pool.submit(self._map_article, source_id, url, guess_dt): url
+                for source_id, url, guess_dt in all_tasks
+            }
+            for fut in futures.as_completed(future_to_url):
+                try:
+                    article = fut.result()
+                    if article is None:
+                        continue
+                    if article.best_timestamp() < cutoff:
+                        continue
+                    _append(article)
+                except Exception:
+                    continue
+
+        return results
+
+
+__all__ = ["NewsFetcher"]

--- a/market_radar/hotness.py
+++ b/market_radar/hotness.py
@@ -1,0 +1,68 @@
+"""Hotness computation for Market Radar articles."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Sequence
+
+from .config import HotnessConfig
+from .models import Article
+
+
+class HotnessCalculator:
+    """Calculate time, density and domain weighted hotness."""
+
+    def __init__(self, config: HotnessConfig, start_time: datetime, window: timedelta) -> None:
+        self.config = config
+        self.start_time = start_time.astimezone(timezone.utc)
+        self.window = window
+        self.cutoff = self.start_time - window
+
+    def time_coef(self, article: Article) -> float:
+        ts = article.best_timestamp().astimezone(timezone.utc)
+        if ts <= self.cutoff:
+            return 0.0
+        if ts >= self.start_time:
+            return 1.0
+        elapsed = (self.start_time - ts).total_seconds()
+        window_seconds = self.window.total_seconds()
+        if window_seconds <= 0:
+            return 1.0
+        ratio = min(max(elapsed / window_seconds, 0.0), 1.0)
+        tail = math.exp(-self.config.time_decay)
+        value = math.exp(-self.config.time_decay * ratio)
+        if value <= tail:
+            return 0.0
+        return (value - tail) / (1.0 - tail)
+
+    def apply(self, articles: Sequence[Article]) -> None:
+        weights = self.config.weights
+        scores = []
+        for art in articles:
+            art.time_coef = self.time_coef(art)
+            density = art.density_coef or 0.0
+            domain = art.domain_coef or 0.0
+            time_component = art.time_coef or 0.0
+            score = (
+                weights.time * time_component
+                + weights.density * density
+                + weights.domain * domain
+            )
+            art.hotness = score
+            scores.append(score)
+
+        if not scores:
+            return
+
+        lo = min(scores)
+        hi = max(scores)
+        for art in articles:
+            score = art.hotness or 0.0
+            if hi > lo:
+                art.hotness = (score - lo) / (hi - lo)
+            else:
+                art.hotness = 1.0 if score > 0 else 0.0
+
+
+__all__ = ["HotnessCalculator"]

--- a/market_radar/models.py
+++ b/market_radar/models.py
@@ -1,0 +1,37 @@
+"""Core data models used by the Market Radar pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Article:
+    """Representation of a parsed news article."""
+
+    source_id: str
+    source_domain: str
+    url: str
+    title: Optional[str]
+    content: Optional[str]
+    published_at: Optional[datetime]
+    crawled_at: datetime
+    language: Optional[str]
+    authors: Optional[List[str]]
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    summary: Optional[str] = None
+    density_coef: Optional[float] = None
+    domain_coef: Optional[float] = None
+    time_coef: Optional[float] = None
+    hotness: Optional[float] = None
+
+    def best_timestamp(self) -> datetime:
+        """Return the best available timestamp (published or crawled)."""
+
+        return self.published_at or self.crawled_at
+
+
+__all__ = ["Article"]

--- a/market_radar/orchestrator.py
+++ b/market_radar/orchestrator.py
@@ -1,0 +1,93 @@
+"""Pipeline orchestrator tying together fetching, density, summarization and hotness."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from .config import PipelineConfig
+from .density_estimator import DensityEstimator
+from .fetching import NewsFetcher
+from .hotness import HotnessCalculator
+from .models import Article
+from .summarizer import Summarizer
+
+
+class NewsPipelineOrchestrator:
+    """High-level orchestrator that runs the Market Radar pipeline."""
+
+    def __init__(self, config: PipelineConfig) -> None:
+        self.config = config
+        self.start_time = datetime.now(timezone.utc)
+        self.time_window_delta = NewsFetcher.parse_since(config.time_window.since)
+
+        self.fetcher = NewsFetcher(config.fetcher, config.time_window)
+        self.density_estimator = DensityEstimator(config.density)
+        self.summarizer = Summarizer(config.summarizer)
+        self.hotness = HotnessCalculator(config.hotness, self.start_time, self.time_window_delta)
+
+    def run(self) -> List[Dict[str, object]]:
+        articles = self.fetcher.fetch(self.start_time)
+        if not articles:
+            self._write_output([])
+            return []
+
+        density_scores = self.density_estimator.estimate(articles)
+        for idx, art in enumerate(articles):
+            art.density_coef = density_scores.get(idx, 0.0)
+
+        self.summarizer.summarize(articles)
+        self.hotness.apply(articles)
+
+        output = self._build_output(articles)
+        self._write_output(output)
+        return output
+
+    def _build_output(self, articles: Sequence[Article]) -> List[Dict[str, object]]:
+        def _to_iso(dt: datetime) -> str:
+            return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        payload: List[Dict[str, object]] = []
+        for art in articles:
+            published = art.published_at or art.crawled_at
+            payload.append(
+                {
+                    "source": art.source_id,
+                    "source_domain": art.source_domain,
+                    "published_at": _to_iso(published),
+                    "url": art.url,
+                    "title": art.title,
+                    "summary": art.summary,
+                    "time_coef": round(float(art.time_coef or 0.0), 6),
+                    "density_coef": round(float(art.density_coef or 0.0), 6),
+                    "domain_coef": round(float(art.domain_coef or 0.0), 6),
+                    "hotness": round(float(art.hotness or 0.0), 6),
+                }
+            )
+
+        payload.sort(key=lambda item: item["hotness"], reverse=True)
+        return payload
+
+    def _write_output(self, data: Sequence[Dict[str, object]]) -> None:
+        path = self.config.output.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def run_from_config(path: Path) -> List[Dict[str, object]]:
+    config = PipelineConfig.from_yaml(path)
+    orchestrator = NewsPipelineOrchestrator(config)
+    return orchestrator.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Market Radar pipeline orchestrator")
+    parser.add_argument("--config", required=True, help="Path to YAML configuration")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    run_from_config(config_path)

--- a/market_radar/summarizer.py
+++ b/market_radar/summarizer.py
@@ -1,0 +1,132 @@
+"""Summarization utilities for Market Radar pipeline."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Dict, Optional, Sequence, Tuple
+
+import httpx
+
+from .config import SummarizerConfig
+from .models import Article
+
+CATS: Dict[str, float] = {
+    "регуляторика/санкции/правовые риски": 1.0,
+    "взломы/инциденты/остановки": 0.9,
+    "существенные тех. прорывы/SOTA": 0.8,
+    "крупные релизы/партнёрства/финансы": 0.7,
+    "маркетинг/«шум»": 0.2,
+}
+CAT_KEYS = {k.lower(): k for k in CATS.keys()}
+
+SYSTEM_PROMPT = (
+    "Ты — финансовый аналитик. Суммаризируй новость по-русски и отнеси её к одной из 5 категорий.\n"
+    "ОТВЕТЬ РОВНО ДВУМЯ СТРОКАМИ, без пояснений и кода:\n"
+    "CATEGORY=<ОДНА категория из списка ниже, БЕЗ изменений формулировки>\n"
+    "SUMMARY=<1–3 коротких предложения с выводом/прогнозом>\n\n"
+    "Категории:\n"
+    "регуляторика/санкции/правовые риски\n"
+    "взломы/инциденты/остановки\n"
+    "существенные тех. прорывы/SOTA\n"
+    "крупные релизы/партнёрства/финансы\n"
+    "маркетинг/«шум»"
+)
+
+CATEGORY_RE = re.compile(r"^\s*CATEGORY\s*=\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+SUMMARY_RE = re.compile(r"^\s*SUMMARY\s*=\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+class Summarizer:
+    """LLM based summarization with graceful fallback."""
+
+    def __init__(self, config: SummarizerConfig) -> None:
+        self.config = config
+        self.api_key = config.api_key or os.getenv("OPENROUTER_API_KEY")
+
+    def _parse_model_output(self, text: str) -> Tuple[str, str]:
+        cat_match = CATEGORY_RE.search(text)
+        sum_match = SUMMARY_RE.search(text)
+        raw_cat = (cat_match.group(1).strip() if cat_match else "").lower()
+        summary = (sum_match.group(1).strip() if sum_match else "").strip()
+
+        if raw_cat in CAT_KEYS:
+            category = CAT_KEYS[raw_cat]
+        else:
+            lr = raw_cat
+            if any(w in lr for w in ["регулятор", "санкц", "правов"]):
+                category = "регуляторика/санкции/правовые риски"
+            elif any(w in lr for w in ["взлом", "инцидент", "останов", "outage", "даунтайм"]):
+                category = "взломы/инциденты/остановки"
+            elif any(w in lr for w in ["sota", "прорыв", "бенчмарк"]):
+                category = "существенные тех. прорывы/SOTA"
+            elif any(w in lr for w in ["релиз", "партнер", "партн", "финанс", "m&a"]):
+                category = "крупные релизы/партнёрства/финансы"
+            else:
+                category = "маркетинг/«шум»"
+
+        if not summary:
+            summary = "Саммари не извлечено: модель вернула нестандартный формат ответа."
+        return category, summary
+
+    def _call_llm(self, title: str, content: str) -> Tuple[str, str]:
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        payload = {
+            "model": self.config.model,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": f"Заголовок: {title}\n\nТекст:\n{content or '(пусто)'}"},
+            ],
+            "temperature": self.config.temperature,
+        }
+
+        backoffs = [0, 1.5, 3.0]
+        last_err: Optional[Exception] = None
+        with httpx.Client(timeout=self.config.timeout) as client:
+            for wait in backoffs:
+                try:
+                    if wait:
+                        time.sleep(wait)
+                    response = client.post(
+                        "https://openrouter.ai/api/v1/chat/completions", headers=headers, json=payload
+                    )
+                    response.raise_for_status()
+                    text = response.json()["choices"][0]["message"]["content"]
+                    return self._parse_model_output(text)
+                except Exception as exc:  # pragma: no cover - network errors
+                    last_err = exc
+        raise RuntimeError(f"LLM call failed after retries: {last_err}")
+
+    def _fallback(self, title: str, content: str) -> Tuple[str, str]:
+        if title:
+            summary = title
+        elif content:
+            summary = content[:280]
+        else:
+            summary = "Нет данных для саммари."
+        return "маркетинг/«шум»", summary
+
+    def summarize_article(self, article: Article) -> Tuple[str, float]:
+        title = article.title or ""
+        content = article.content or ""
+        if not self.api_key:
+            category, summary = self._fallback(title, content)
+        else:
+            try:
+                category, summary = self._call_llm(title, content)
+            except Exception:
+                if not self.config.fallback_summary:
+                    raise
+                category, summary = self._fallback(title, content)
+        weight = CATS.get(category, min(CATS.values()))
+        article.summary = summary
+        article.domain_coef = weight
+        return category, weight
+
+    def summarize(self, articles: Sequence[Article]) -> None:
+        for article in articles:
+            self.summarize_article(article)
+
+
+__all__ = ["Summarizer"]


### PR DESCRIPTION
## Summary
- refactor the project into a reusable `market_radar` package with configuration loaders, fetcher, density estimator, summarizer, and hotness calculator classes
- add an orchestrator that reads YAML configuration and produces the consolidated hotness-ranked JSON output
- provide an example YAML config to demonstrate pipeline wiring and parameterization

## Testing
- python -m compileall market_radar

------
https://chatgpt.com/codex/tasks/task_e_68e12ee74c6c832f8929bb3f403a44c5