### PR TITLE
Allow configuring API via CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN pip install --upgrade pip \
 
 COPY . .
 
-ENV MARKET_RADAR_CONFIG=/app/config.yaml \
-    MARKET_RADAR_MODEL_CACHE=/app/models \
+ENV MARKET_RADAR_MODEL_CACHE=/app/models \
     HF_HOME=/app/models \
     TRANSFORMERS_CACHE=/app/models \
     SENTENCE_TRANSFORMERS_HOME=/app/models \
@@ -29,4 +28,5 @@ ENV MARKET_RADAR_CONFIG=/app/config.yaml \
 
 EXPOSE 8000
 
-CMD ["python", "-m", "market_radar"]
+ENTRYPOINT ["python", "-m", "market_radar"]
+CMD ["--config", "/app/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -98,28 +98,23 @@ returns the ranked articles as JSON.
 ### Run locally
 
 ```bash
-uvicorn market_radar.api:create_app --factory --host 0.0.0.0 --port 8000
+python -m market_radar --config $(pwd)/config.yaml --port 8000
 ```
 
-Send a request to trigger the pipeline (uploading a custom configuration is optional):
+Send a request to trigger the pipeline:
 
 ```bash
 curl -X POST \
-  -F "config_file=@$(pwd)/config.yaml" \
-  "http://localhost:8000/pipeline?since=6h&limit=10"
+  "http://localhost:8000/pipeline?output_path=$(pwd)/output.json&since=6h"
 ```
 
 Available query parameters:
 
-- `since` – override `time_window.since` (e.g. `6h`).
-- `max_per_source` – limit the number of articles pulled per RSS source.
-- `limit` – trim the number of records returned in the JSON response.
-- `sources_path` – override the RSS sources JSON used by the fetcher.
-- `output_path` – specify a custom location for the generated report on disk.
+- `output_path` – **required**, specifies where the generated JSON report is written.
+- `since` – optional override for `time_window.since` (e.g. `6h`).
 
-If `config_file` is omitted, the API loads the configuration pointed to by
-`MARKET_RADAR_CONFIG` or falls back to `config.example.yaml` and applies the
-query-parameter overrides.
+All other configuration values are sourced exclusively from the YAML file
+provided when the service starts.
 
 Set `MARKET_RADAR_MODEL_CACHE` (or the common `HF_HOME`/`TRANSFORMERS_CACHE`)
 to reuse a persistent cache for Sentence Transformers weights.

--- a/market_radar/__main__.py
+++ b/market_radar/__main__.py
@@ -2,18 +2,50 @@
 
 from __future__ import annotations
 
+import argparse
 import os
+from pathlib import Path
+from typing import Sequence
 
 import uvicorn
 
+from .api import configure_default_config_path
 
-def main() -> None:
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for launching the API service."""
+
+    parser = argparse.ArgumentParser(description="Run the Market Radar API service")
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the YAML configuration file used by the pipeline",
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Hostname or IP address to bind the API server",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port to bind the API server (defaults to $PORT or 8000)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
     """Launch the FastAPI application with Uvicorn."""
 
-    port = int(os.getenv("PORT", "8000"))
+    args = parse_args(argv)
+    configure_default_config_path(Path(args.config))
+
+    port = args.port if args.port is not None else int(os.getenv("PORT", "8000"))
+
     uvicorn.run(
         "market_radar.api:create_app",
-        host="0.0.0.0",
+        host=args.host,
         port=port,
         factory=True,
         reload=False,

--- a/tools/run_api_container.sh
+++ b/tools/run_api_container.sh
@@ -65,7 +65,6 @@ RUN_ARGS=(
   docker run --rm
   -p "${PORT}:${PORT}"
   -e "PORT=${PORT}"
-  -e "MARKET_RADAR_CONFIG=${CONFIG_PATH_ABS}"
   -e "MARKET_RADAR_MODEL_CACHE=/app/models"
   -e "HF_HOME=/app/models"
   -e "TRANSFORMERS_CACHE=/app/models"
@@ -86,7 +85,7 @@ if [[ ${DEV} -eq 1 ]]; then
   RUN_ARGS+=( -v "$(pwd):/app:ro" )
 fi
 
-RUN_ARGS+=( "${IMAGE_NAME}" )
+RUN_ARGS+=( "${IMAGE_NAME}" "--config" "${CONFIG_PATH_ABS}" )
 
 echo "Executing: ${RUN_ARGS[*]}"
 exec "${RUN_ARGS[@]}"


### PR DESCRIPTION
## Summary
- add a CLI layer that requires providing the pipeline configuration file when launching the API service
- plumb the configured path into the FastAPI factory while keeping runtime overrides limited to `since` and `output_path`
- update Docker/container tooling and documentation to reflect the CLI-based startup flow

## Testing
- python -m compileall market_radar

------
https://chatgpt.com/codex/tasks/task_e_68e14b3e3968832faef1a0619062e92b